### PR TITLE
Install mbuild from my fork as temporary fix to shift_coords causing particles out-of-box

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,8 +7,12 @@ dependencies:
   - python=3.7
   - pip
   - numpy
+  - scipy
+  - packmol>=1!18.013
+  - oset
+  - parmed
+  - networkx
   - matplotlib
-  - mbuild
   - openbabel
   - foyer
   - gsd
@@ -19,3 +23,4 @@ dependencies:
   - signac-flow
   - pip:
     - "--editable=git+git@github.com:rsdefever/GAFF-foyer.git#egg=GAFF-foyer-master"
+    - "--editable=git+git@github.com:chrisjonesBSU/mbuild.git@bsu-uli#egg=mbuild-bsu-uli"


### PR DESCRIPTION
removed mbuild install from anaconda, added my fork and branch with s…hift_coords fix, also added some of the mbuild dependencies to install from conda.

Solves issue #6 