### PR TITLE
the oxygen on the terminal monomer now has the hydrogen it needs

### DIFF
--- a/uli_init/simulate.py
+++ b/uli_init/simulate.py
@@ -192,6 +192,7 @@ class System():
                  pdi=None,
                  M_n=None,
                  remove_hydrogens=False,
+                 assert_dihedrals=True,
                  seed=24
                 ):
         self.molecule = molecule
@@ -201,6 +202,7 @@ class System():
         self.remove_hydrogens = remove_hydrogens
         self.pdi = pdi
         self.forcefield = forcefield
+        self.assert_dihedral = assert_dihedrals
         self.seed = seed
         self.system_mass = 0
         self.para = 0 # keep track for now to check things are working, maybe keep?
@@ -265,7 +267,8 @@ class System():
         elif self.forcefield == 'opls':
             forcefield = foyer.Forcefield(name='oplsaa')
 
-        typed_system = forcefield.apply(self.system_mb)
+        typed_system = forcefield.apply(self.system_mb,
+                                        assert_dihedral_params=self.assert_dihedral)
         if self.remove_hydrogens: # not sure how to do this with Parmed yet
             removed_hydrogen_count = 0 # subtract from self.mass
             pass
@@ -321,6 +324,8 @@ def build_molecule(molecule, length, para_weight):
     for idx, config in enumerate(monomer_sequence):
         if idx == 0: # append template, but not brackets
             monomer_string = mol_dict['{}_template'.format(config)]
+            if molecule == 'PEEK': # Change oxygen type on the terminal end of the polymer; needs its hydrogen.
+                monomer_string = "O"+monomer_string[1:]
             molecule_string = molecule_string.format(monomer_string)
             if len(monomer_sequence) == 1:
                 molecule_string = molecule_string.replace('{}', '')

--- a/uli_init/system-init.ipynb
+++ b/uli_init/system-init.ipynb
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -220,6 +220,7 @@
     "                 pdi=None,\n",
     "                 M_n=None,\n",
     "                 remove_hydrogens=False,\n",
+    "                 assert_dihedrals=True,\n",
     "                 seed=24\n",
     "                ):\n",
     "        self.molecule = molecule\n",
@@ -229,6 +230,7 @@
     "        self.remove_hydrogens = remove_hydrogens\n",
     "        self.pdi = pdi\n",
     "        self.forcefield = forcefield\n",
+    "        self.assert_dihedrals = assert_dihedrals\n",
     "        self.seed = seed\n",
     "        self.system_mass = 0\n",
     "        self.para = 0 # keep track for now to check things are working, maybe keep?\n",
@@ -294,7 +296,8 @@
     "        elif self.forcefield == 'opls':\n",
     "            forcefield = foyer.Forcefield(name='oplsaa')\n",
     "        \n",
-    "        typed_system = forcefield.apply(self.system_mb)\n",
+    "        typed_system = forcefield.apply(self.system_mb,\n",
+    "                                       assert_dihedral_params=self.assert_dihedrals)\n",
     "        if self.remove_hydrogens: # not sure how to do this with Parmed yet\n",
     "            removed_hydrogen_count = 0 # subtract from self.mass\n",
     "            pass    \n",
@@ -346,6 +349,8 @@
     "    for idx, config in enumerate(monomer_sequence):\n",
     "        if idx == 0: # append template, but not brackets\n",
     "            monomer_string = mol_dict['{}_template'.format(config)]\n",
+    "            if molecule == 'PEEK':\n",
+    "                monomer_string = \"O\" + monomer_string[1:]\n",
     "            molecule_string = molecule_string.format(monomer_string)\n",
     "            if len(monomer_sequence) == 1:\n",
     "                molecule_string = molecule_string.replace('{}', '')\n",
@@ -389,15 +394,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 10,
    "metadata": {
     "scrolled": false
    },
    "outputs": [],
    "source": [
     "test_system = System(molecule=\"PEEK\", para_weight=0.60,\n",
-    "                    density=1, n_compounds=[10], polymer_lengths=[5],\n",
-    "                    forcefield='gaff')"
+    "                    density=1, n_compounds=[5], polymer_lengths=[5],\n",
+    "                    forcefield='gaff', assert_dihedrals=True)"
    ]
   },
   {


### PR DESCRIPTION
The oxygen atom bonded to the benzene in PEEK didn't have a hydrogen, meaning it was forming a double bond with the aromatic carbon.  This is only an issue at the terminal monomer since the monomer-monomer bonds occurred at this oxygen.  Quick change for now is to change the 'o' to 'O' at the beginning of the completed SMILES string.  Maybe a future fix will be expanding the .json compound files with SMILES strings for terminal monomers.

I also added parameters to the System class that allow us to set assert_dihedrals to False when using foyer's apply() function.