### PR TITLE
Install mbuild from anaconda rather than my fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ To configure hoomd to run on GPUs, following the installation instructions found
 pip install -e .
 ```
 
+### 5. Install the GAFF-Foyer repository ###
+```
+cd path-to-your-repos
+git clone git@github.com:rsdefever/GAFF-foyer.git
+cd  GAFF-foyer
+pip install -e .
+```
+
 ## Basic Usage
 
 So far, essentially all of the functionality lives in the `simulate.py` file

--- a/environment.yml
+++ b/environment.yml
@@ -2,25 +2,18 @@ name: uli
 channels:
   - conda-forge
   - omnia
-  - mosdef
 dependencies:
   - python=3.7
-  - pip
+  - pip=19.3
+  - mbuild 
+  - foyer
   - numpy
   - scipy
-  - packmol>=1!18.013
-  - oset
-  - parmed
-  - networkx
   - matplotlib
-  - openbabel
-  - foyer
   - gsd
   - py3dmol
   - deepsmiles
-  - ele
   - signac
   - signac-flow
   - pip:
     - "--editable=git+git@github.com:rsdefever/GAFF-foyer.git#egg=GAFF-foyer-master"
-    - "--editable=git+git@github.com:chrisjonesBSU/mbuild.git@bsu-uli#egg=mbuild-bsu-uli"

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - omnia
 dependencies:
   - python=3.7
-  - pip=19.3
+  - pip
   - mbuild 
   - foyer
   - numpy
@@ -15,5 +15,3 @@ dependencies:
   - deepsmiles
   - signac
   - signac-flow
-  - pip:
-    - "--editable=git+git@github.com:rsdefever/GAFF-foyer.git#egg=GAFF-foyer-master"


### PR DESCRIPTION
The `environment.yml` file was using a branch on my fork of mbuild to fix the particle out of box issues. The latest version of mbuild contains a PR that fixes the issue, so the environment file now installs mbuild from anaconda rather than my fork.  

Also, having pip install the GAFF-foyer repo from the environment.yml file was causing a few issues. First, I think it was why foyer defaulted to using the `.xml` file that didn't have SMARTS definitions which caused the `ff.apply()` step to error out. Second, it didn't work with the latest version of pip (for reasons beyond my understanding). So, for now the fix is to install GAFF-foyer in a separate step which is outlined in the README.md file.  We can revisit it later if we want to incorporate it back into the environment file for the sake of making the environment set up as simple as possible.

Addresses #21 