### PR TITLE
Fix/anneal

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,4 @@ dependencies:
   - deepsmiles
   - signac
   - signac-flow
+  - pytest


### PR DESCRIPTION
Fixed a few issues in the anneal function.

ran the shrink steps, disabled shrink gsd and box resize.

Changed gsd file name to the same as what is used in quench.

Removed adding up previous steps in the `hoomd.run` call in the for loop. 