### PR TITLE
Fix/unit conv

### DIFF
--- a/uli_init/utils/base_units.py
+++ b/uli_init/utils/base_units.py
@@ -8,10 +8,7 @@ def base_units():
     units['cm_to_nm'] = 1e7
     units["nm_to_m"] = 1e-9
     units["m_to_nm"] = 1e9
-    units["mass"] = 32.06
     units["mass_units"] = "amu"
-    units["energy"] = 1.046
     units["energy_units"] = "kj/mol"
-    units["distance"] = 0.35635948725613575
     units["distance_units"] = "nm"
     return units

--- a/uli_init/utils/base_units.py
+++ b/uli_init/utils/base_units.py
@@ -6,7 +6,8 @@ def base_units():
     units["amu_to_kg"] = 1.6605e-27
     units["amu_to_g"] = 1.6605e-24
     units['cm_to_nm'] = 1e7
-    units["m_to_nm"] = 1e-9
+    units["nm_to_m"] = 1e-9
+    units["m_to_nm"] = 1e9
     units["mass"] = 32.06
     units["mass_units"] = "amu"
     units["energy"] = 1.046

--- a/uli_init/utils/unit_conversions.py
+++ b/uli_init/utils/unit_conversions.py
@@ -1,5 +1,4 @@
-from planckton.utils import base_units
-
+from uli_init.utils import base_units
 
 def reduce_from_kelvin(T_SI, ref_energy, precision=2):
     units = base_units.base_units()

--- a/uli_init/utils/unit_conversions.py
+++ b/uli_init/utils/unit_conversions.py
@@ -1,29 +1,29 @@
 from planckton.utils import base_units
 
 
-def reduce_from_kelvin(T_SI, precision=2):
+def reduce_from_kelvin(T_SI, ref_energy, precision=2):
     units = base_units.base_units()
     T = (units["avogadro"] * units["boltzmann"] * T_SI) / (
-        units["kj_to_j"] * units["energy"]
+        units["kj_to_j"] * ref_energy
     )
     T = round(T, precision)
     return T
 
 
-def kelvin_from_reduced(T_reduced, precision=0):
+def kelvin_from_reduced(T_reduced, ref_energy, precision=0):
     units = base_units.base_units()
-    T_SI = (T_reduced * units["energy"] * units["kj_to_j"]) / (
+    T_SI = (T_reduced * ref_energy * units["kj_to_j"]) / (
         units["avogadro"] * units["boltzmann"]
     )
     T_SI = round(T_SI, precision)
     return T_SI
 
 
-def convert_to_real_time(dt, precision=3):
+def convert_to_real_time(dt, ref_energy, ref_distance, ref_mass, precision=3):
     units = base_units.base_units()
-    time_tau = units["mass"] * units["amu_to_kg"]
-    time_tau *= (units["distance"] * units["nm_to_m"]) ** 2
-    time_tau /= units["energy"] * units["kj_to_j"] / units["avogadro"]
+    time_tau = ref_mass * units["amu_to_kg"]
+    time_tau *= (ref_distance * units["nm_to_m"]) ** 2
+    time_tau /= ref_energy * units["kj_to_j"] / units["avogadro"]
     real_time = dt * (time_tau ** 0.5) * 1e15
     real_time = round(real_time, precision)
     return real_time


### PR DESCRIPTION
The `unit_conversion.py` and `base_units.py` were still unchanged from when I copied them over from planckton. I made the fixes as well as updating the functions to use the reference values determined in `simulate.py` rather than the fixed values planckton used.