### PR TITLE
Add wall potentials

### DIFF
--- a/Notebooks/add-walls.ipynb
+++ b/Notebooks/add-walls.ipynb
@@ -1,0 +1,249 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/chris/miniconda3/envs/uli/lib/python3.7/site-packages/ipykernel/ipkernel.py:283: DeprecationWarning: `should_run_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.\n",
+      "  and should_run_async(code)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from uli_init import simulate\n",
+    "import hoomd\n",
+    "import gsd\n",
+    "import mbuild as mb\n",
+    "from mbuild.formats.hoomd_simulation import create_hoomd_simulation\n",
+    "import hoomd.md\n",
+    "from hoomd.md import wall"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/chris/miniconda3/envs/uli/lib/python3.7/site-packages/ipykernel/ipkernel.py:283: DeprecationWarning: `should_run_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.\n",
+      "  and should_run_async(code)\n",
+      "/home/chris/cme/forks/uli-init/uli_init/simulate.py:321: DeprecationWarning: Calling np.sum(generator) is deprecated, and in the future will give a different result. Use np.sum(np.fromiter(generator)) or the python sum builtin instead.\n",
+      "  mass = _n * np.sum(ele.element_from_symbol(p.name).mass for p in polymer.particles())\n",
+      "/home/chris/miniconda3/envs/uli/lib/python3.7/site-packages/foyer/forcefield.py:449: UserWarning: No force field version number found in force field XML file.\n",
+      "  'No force field version number found in force field XML file.'\n",
+      "/home/chris/miniconda3/envs/uli/lib/python3.7/site-packages/foyer/forcefield.py:461: UserWarning: No force field name found in force field XML file.\n",
+      "  'No force field name found in force field XML file.'\n",
+      "/home/chris/miniconda3/envs/uli/lib/python3.7/site-packages/foyer/validator.py:132: ValidationWarning: You have empty smart definition(s)\n",
+      "  warn(\"You have empty smart definition(s)\", ValidationWarning)\n",
+      "/home/chris/miniconda3/envs/uli/lib/python3.7/site-packages/foyer/forcefield.py:267: UserWarning: Parameters have not been assigned to all impropers. Total system impropers: 1140, Parameterized impropers: 800. Note that if your system contains torsions of Ryckaert-Bellemans functional form, all of these torsions are processed as propers\n",
+      "  warnings.warn(msg)\n"
+     ]
+    }
+   ],
+   "source": [
+    "system = simulate.System('PEEK', 1.0, 0.8, 20, 3, 'gaff')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/chris/miniconda3/envs/uli/lib/python3.7/site-packages/ipykernel/ipkernel.py:283: DeprecationWarning: `should_run_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.\n",
+      "  and should_run_async(code)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['__class__',\n",
+       " '__delattr__',\n",
+       " '__dict__',\n",
+       " '__dir__',\n",
+       " '__doc__',\n",
+       " '__eq__',\n",
+       " '__format__',\n",
+       " '__ge__',\n",
+       " '__getattribute__',\n",
+       " '__gt__',\n",
+       " '__hash__',\n",
+       " '__init__',\n",
+       " '__init_subclass__',\n",
+       " '__le__',\n",
+       " '__lt__',\n",
+       " '__module__',\n",
+       " '__ne__',\n",
+       " '__new__',\n",
+       " '__reduce__',\n",
+       " '__reduce_ex__',\n",
+       " '__repr__',\n",
+       " '__setattr__',\n",
+       " '__sizeof__',\n",
+       " '__str__',\n",
+       " '__subclasshook__',\n",
+       " '__weakref__',\n",
+       " '_calculate_L',\n",
+       " '_pack',\n",
+       " '_recover_mass_dist',\n",
+       " '_type_system',\n",
+       " '_weibull_k_expression',\n",
+       " '_weibull_lambda_expression',\n",
+       " 'assert_dihedrals',\n",
+       " 'density',\n",
+       " 'epsilon',\n",
+       " 'forcefield',\n",
+       " 'meta',\n",
+       " 'molecule',\n",
+       " 'n_compounds',\n",
+       " 'para',\n",
+       " 'para_weight',\n",
+       " 'polymer_lengths',\n",
+       " 'remove_hydrogens',\n",
+       " 'seed',\n",
+       " 'system_mass',\n",
+       " 'system_mb',\n",
+       " 'system_pmd',\n",
+       " 'target_L']"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dir(system)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "notice(2): Group \"all\" created containing 2080 particles\n",
+      "notice(2): -- Neighborlist exclusion statistics -- :\n",
+      "notice(2): Particles with 2 exclusions             : 20\n",
+      "notice(2): Particles with 3 exclusions             : 800\n",
+      "notice(2): Particles with 4 exclusions             : 20\n",
+      "notice(2): Particles with 6 exclusions             : 100\n",
+      "notice(2): Particles with 7 exclusions             : 800\n",
+      "notice(2): Particles with 8 exclusions             : 220\n",
+      "notice(2): Particles with 9 exclusions             : 120\n",
+      "notice(2): Neighbors included by diameter          : no\n",
+      "notice(2): Neighbors excluded when in the same body: no\n",
+      "Processing LJ and QQ\n",
+      "notice(2): Group \"charged\" created containing 0 particles\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/chris/miniconda3/envs/uli/lib/python3.7/site-packages/ipykernel/ipkernel.py:283: DeprecationWarning: `should_run_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.\n",
+      "  and should_run_async(code)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No charged groups found, ignoring electrostatics\n",
+      "Processing 1-4 interactions, adjusting neighborlist exclusions\n",
+      "Processing harmonic bonds\n",
+      "Processing harmonic angles\n",
+      "Processing periodic torsions\n",
+      "HOOMD SimulationContext updated from ParmEd Structure\n"
+     ]
+    }
+   ],
+   "source": [
+    "hoomd_args = f\"--single-mpi --mode={'gpu'}\"\n",
+    "sim = hoomd.context.initialize(hoomd_args)\n",
+    "with sim:\n",
+    "    objs, refs = create_hoomd_simulation(system.system_pmd, r_cut=1.2, auto_scale=True)\n",
+    "        # refs = distance, mass, energy\n",
+    "    snap = objs[0]\n",
+    "    _all = hoomd.group.all()\n",
+    "    hoomd.md.integrate.mode_standard(dt=0.0001)\n",
+    "    integrator = hoomd.md.integrate.nvt(group=_all, kT=1.0, tau=0.1)\n",
+    "    hoomd.dump.gsd(\"trajectories/wall-squeeze.gsd\", period=1e4, group=_all, phase=0, overwrite=True)\n",
+    "    integrator.randomize_velocities(seed=42);\n",
+    " \n",
+    "    # Set up a wall:\n",
+    "    wall_origin = (snap.box.Lx/2, 0, 0)\n",
+    "    normal_vector = (-1, 0, 0)\n",
+    "    wall_origin2 = (-snap.box.Lx/2, 0, 0)\n",
+    "    normal_vector2 = (1, 0, 0)\n",
+    "    \n",
+    "    walls = wall.group(\n",
+    "                       wall.plane(origin=wall_origin, normal=normal_vector, inside = True),\n",
+    "                       wall.plane(origin=wall_origin2, normal=normal_vector2, inside = True)\n",
+    "                      )\n",
+    "    wall_force = wall.lj(walls, r_cut=snap.box.Lx/4)\n",
+    "    #wall_force = wall.???\n",
+    "    wall_force.force_coeff.set(snap.particles.types, sigma=1.0, epsilon=1.0, r_extrap=1.0)\n",
+    "    \n",
+    "    # Set up shrink:\n",
+    "    reduced_target_L = system.target_L / refs[0]\n",
+    "    reduced_init_L = system.system_pmd.box[0] / refs[0]\n",
+    "    target_box = [reduced_target_L]*3\n",
+    "    shrink_steps = 1e4\n",
+    "    \n",
+    "    x_variant = hoomd.variant.linear_interp([(0, reduced_init_L),\n",
+    "                                             (shrink_steps, target_box[0]*10)])\n",
+    "    y_variant = hoomd.variant.linear_interp([(0, reduced_init_L),\n",
+    "                                             (shrink_steps, target_box[1]*10)])\n",
+    "    z_variant = hoomd.variant.linear_interp([(0, reduced_init_L),\n",
+    "                                             (shrink_steps, target_box[2]*10)])\n",
+    "    box_updater = hoomd.update.box_resize(Lx = x_variant, Ly = y_variant, Lz = z_variant)\n",
+    " \n",
+    "    \n",
+    "    \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,0 +1,27 @@
+name: uli-dev
+channels:
+  - conda-forge
+  - omnia
+  - mosdef
+dependencies:
+  - python=3.7
+  - pip
+  - ele
+  - garnett
+  - mdtraj
+  - networkx
+  - openbabel
+  - oset
+  - packmol
+  - parmed
+  - scipy
+  - foyer
+  - numpy
+  - scipy
+  - matplotlib
+  - gsd
+  - py3dmol
+  - deepsmiles
+  - signac
+  - signac-flow
+  - pytest

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,4 +1,4 @@
-name: uli-dev-test
+name: uli-dev
 channels:
   - conda-forge
   - omnia

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,4 +1,4 @@
-name: uli-dev
+name: uli-dev-test
 channels:
   - conda-forge
   - omnia
@@ -25,3 +25,5 @@ dependencies:
   - signac
   - signac-flow
   - pytest
+  - pip:
+      - git+https://github.com/chrisjonesBSU/mbuild.git@hoomd_sim

--- a/environment.yml
+++ b/environment.yml
@@ -1,11 +1,20 @@
-name: uli
+name: uli-dev-test
 channels:
   - conda-forge
   - omnia
+  - mosdef
 dependencies:
   - python=3.7
   - pip
-  - mbuild 
+  - ele
+  - garnett
+  - mdtraj
+  - networkx
+  - openbabel
+  - oset
+  - packmol
+  - parmed
+  - scipy
   - foyer
   - numpy
   - scipy
@@ -16,3 +25,5 @@ dependencies:
   - signac
   - signac-flow
   - pytest
+  - pip:
+      - git+https://github.com/chrisjonesBSU/mbuild.git@hoomd_sim

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: uli-dev-test
+name: uli
 channels:
   - conda-forge
   - omnia

--- a/uli_init/simulate.py
+++ b/uli_init/simulate.py
@@ -17,6 +17,7 @@ import operator
 from collections import namedtuple
 import scipy.optimize
 from scipy.special import gamma
+import time
 
 units = base_units.base_units()
 
@@ -128,15 +129,17 @@ class Simulation():
                 wall_force.force_coeff.set(init_snap.particles.types, sigma=1.0, epsilon=1.0, r_extrap=0)
                 
                 step = 0
+                start = time.time()
                 while step < shrink_steps:
                     hoomd.run_upto(step + shrink_period)
-                    snap = self.hoomd_system.take_snapshot()
+                    current_box = self.hoomd_system.box
                     walls.del_plane([0,1])
-                    walls.add_plane((snap.box.Lx/2, 0, 0), normal_vector)
-                    walls.add_plane((-snap.box.Lx/2,0, 0), normal_vector2)
+                    walls.add_plane((current_box.Lx/2, 0, 0), normal_vector)
+                    walls.add_plane((-current_box.Lx/2, 0, 0), normal_vector2)
                     step += shrink_period 
                     print('Finished step {} of {}'.format(step, shrink_steps))
-                    print('Shrinking is {}% complete'.format(round(step/shrink_steps, 5)))
+                    print('Shrinking is {}% complete'.format(round(step/shrink_steps, 5)*100))
+                    print('time elapsed: {}'.format(time.time() - start))
             else:
                 hoomd.run_upto(shrink_steps)
 
@@ -216,10 +219,10 @@ class Simulation():
                 step = 0
                 while step < shrink_steps:
                     hoomd.run_upto(step + shrink_period)
-                    snap = hoomd_system.take_snapshot()
+                    current_box = self.hoomd_system.box
                     walls.del_plane([0,1])
-                    walls.add_plane((snap.box.Lx/2, 0, 0), normal_vector)
-                    walls.add_plane((-snap.box.Lx/2,0, 0), normal_vector2)
+                    walls.add_plane((current_box.Lx/2, 0, 0), normal_vector)
+                    walls.add_plane((-current_box.Lx/2, 0, 0), normal_vector2)
                     step += shrink_period 
             else:
                 hoomd.run_upto(shrink_steps)

--- a/uli_init/simulate.py
+++ b/uli_init/simulate.py
@@ -135,6 +135,8 @@ class Simulation():
                     walls.add_plane((snap.box.Lx/2, 0, 0), normal_vector)
                     walls.add_plane((-snap.box.Lx/2,0, 0), normal_vector2)
                     step += shrink_period 
+                    print('Finished step {} of {}'.format(step, shrink_steps))
+                    print('Shrinking is {}% complete'.format(round(step/shrink_steps, 5)))
             else:
                 hoomd.run_upto(shrink_steps)
 

--- a/uli_init/simulate.py
+++ b/uli_init/simulate.py
@@ -95,7 +95,7 @@ class Simulation():
             objs, refs = create_hoomd_simulation(self.system_pmd, self.ref_distance,
                                     self.ref_mass, self.ref_energy,
                                     self.r_cut, self.auto_scale)
-            self.hoomd_system = objs[1]
+            hoomd_system = objs[1]
             init_snap = objs[0]
             _all = hoomd.group.all()
             hoomd.md.integrate.mode_standard(dt=self.dt)
@@ -132,7 +132,7 @@ class Simulation():
                 start = time.time()
                 while step < shrink_steps:
                     hoomd.run_upto(step + shrink_period)
-                    current_box = self.hoomd_system.box
+                    current_box = hoomd_system.box
                     walls.del_plane([0,1])
                     walls.add_plane((current_box.Lx/2, 0, 0), normal_vector)
                     walls.add_plane((-current_box.Lx/2, 0, 0), normal_vector2)
@@ -219,7 +219,7 @@ class Simulation():
                 step = 0
                 while step < shrink_steps:
                     hoomd.run_upto(step + shrink_period)
-                    current_box = self.hoomd_system.box
+                    current_box = hoomd_system.box
                     walls.del_plane([0,1])
                     walls.add_plane((current_box.Lx/2, 0, 0), normal_vector)
                     walls.add_plane((-current_box.Lx/2, 0, 0), normal_vector2)

--- a/uli_init/tests/test_simulations.py
+++ b/uli_init/tests/test_simulations.py
@@ -10,7 +10,7 @@ class TestSimulate(BaseTest):
     def test_anneal(self, pekk_system):
         simulation = simulate.Simulation(pekk_system, dt = 0.0001, mode='cpu')
         simulation.anneal(kT_init=4, kT_final=2,
-                            step_sequence=[1e3, 1e3, 1e3],
+                            step_sequence=[1e3, 1e3],
                             shrink_steps=1e3,
                             walls=False)
 
@@ -25,7 +25,13 @@ class TestSimulate(BaseTest):
                             shrink_steps=1e3,
                             walls=False)
    
-    def test_walls(self, peek_system_noH):
+    def test_walls_quench(self, peek_system_noH):
         simulation = simulate.Simulation(peek_system_noH, dt = 0.001, mode='cpu')
         simulation.quench(kT=2, n_steps=1e3, shrink_steps=1e3, walls=True)
 
+    def test_walls_anneal(self, peek_system_noH):
+        simulation = simulate.Simulation(peek_system_noH, dt = 0.001, mode='cpu')
+        simulation.anneal(kT_init=4, kT_final=2,
+                        step_sequence=[1e3, 1e3],
+                        shrink_steps=1e3,
+                        walls=True)

--- a/uli_init/tests/test_simulations.py
+++ b/uli_init/tests/test_simulations.py
@@ -5,20 +5,27 @@ class TestSimulate(BaseTest):
 
     def test_quench(self, peek_system):
         simulation = simulate.Simulation(peek_system, dt=0.0001, mode='cpu')
-        simulation.quench(kT=2, n_steps=2e3, shrink_steps=1e3)
+        simulation.quench(kT=2, n_steps=1e3, shrink_steps=1e3, walls=False)
 
     def test_anneal(self, pekk_system):
         simulation = simulate.Simulation(pekk_system, dt = 0.0001, mode='cpu')
         simulation.anneal(kT_init=4, kT_final=2,
                             step_sequence=[1e3, 1e3, 1e3],
-                            shrink_steps=1e3)
+                            shrink_steps=1e3,
+                            walls=False)
 
     def test_quench_noH(self, pekk_system_noH):
         simulation = simulate.Simulation(pekk_system_noH, dt=0.001, mode='cpu')
-        simulation.quench(kT=2, n_steps=2e3, shrink_steps=1e3)
+        simulation.quench(kT=2, n_steps=1e3, shrink_steps=1e3, walls=False)
 
     def test_anneal_noH(self, peek_system_noH):
         simulation = simulate.Simulation(peek_system_noH, dt = 0.001, mode='cpu')
         simulation.anneal(kT_init=4, kT_final=2,
                             step_sequence=[1e3, 1e3, 1e3],
-                            shrink_steps=1e3)
+                            shrink_steps=1e3,
+                            walls=False)
+   
+    def test_walls(self, peek_system_noH):
+        simulation = simulate.Simulation(peek_system_noH, dt = 0.001, mode='cpu')
+        simulation.quench(kT=2, n_steps=1e3, shrink_steps=1e3, walls=True)
+


### PR DESCRIPTION
functionality added to create wall potentials on both sides of a box along the same axis. They are added during the shrink step, and updated with the box during shrink and remain in place for the whole simulation.