### PR TITLE
Using kcal/mol and ang; added tests for conversions and base units

### DIFF
--- a/uli_init/tests/test_conversions.py
+++ b/uli_init/tests/test_conversions.py
@@ -1,5 +1,4 @@
 from uli_init.utils import base_units, unit_conversions
-import numpy as np
 
 def test_kelvin_from_reduced():
     kT = 4

--- a/uli_init/tests/test_conversions.py
+++ b/uli_init/tests/test_conversions.py
@@ -1,0 +1,34 @@
+from uli_init.utils import base_units, unit_conversions
+import numpy as np
+
+def test_kelvin_from_reduced():
+    kT = 4
+    ref_energy = .2104 # ref_energy for PEEK/PEKK kcal/mol
+    kelvin = unit_conversions.kelvin_from_reduced(kT, ref_energy)
+    assert kelvin == 424
+
+def test_reduced_from_kT():
+    kelvin = 424
+    ref_energy = .2104
+    kT = unit_conversions.reduce_from_kelvin(kelvin, ref_energy)
+    assert kT == 4
+
+def test_convert_to_real_time():
+    ref_energy = .2104
+    ref_mass = 15.99943 # ref_mass for PEEK/PEKK amu
+    ref_distance = 3.3996695084235347 #ref_dist for PEEK/PEKK ang
+    dt = 0.001
+    real_time = unit_conversions.convert_to_real_time(
+                    dt,
+                    ref_energy,
+                    ref_distance,
+                    ref_mass
+    )                               
+    assert real_time == 1.449
+
+def test_base_units():# Test the conversion factors used in unit_conversions.py
+    assert base_units.base_units()["kcal_to_j"] == 4184
+    assert base_units.base_units()["amu_to_kg"] == 1.6605e-27
+    assert base_units.base_units()["ang_to_m"] == 1e-10
+    assert base_units.base_units()["boltzmann"] == 1.38064852e-23
+    assert base_units.base_units()["avogadro"] == 6.022140857e23

--- a/uli_init/utils/base_units.py
+++ b/uli_init/utils/base_units.py
@@ -3,12 +3,15 @@ def base_units():
     units["avogadro"] = 6.022140857e23
     units["boltzmann"] = 1.38064852e-23
     units["kj_to_j"] = 1e3
+    units["kcal_to_j"] = 4184
     units["amu_to_kg"] = 1.6605e-27
     units["amu_to_g"] = 1.6605e-24
     units["cm_to_nm"] = 1e7
     units["nm_to_m"] = 1e-9
+    units["ang_to_m"] = 1e-10
     units["m_to_nm"] = 1e9
+    units["m_to_ang"] = 1e10
     units["mass_units"] = "amu"
-    units["energy_units"] = "kj/mol"
-    units["distance_units"] = "nm"
+    units["energy_units"] = "kcal/mol"
+    units["distance_units"] = "angstroms"
     return units

--- a/uli_init/utils/unit_conversions.py
+++ b/uli_init/utils/unit_conversions.py
@@ -1,10 +1,9 @@
 from uli_init.utils import base_units
 
-
 def reduce_from_kelvin(T_SI, ref_energy, precision=2):
     units = base_units.base_units()
     T = (units["avogadro"] * units["boltzmann"] * T_SI) / (
-        units["kj_to_j"] * ref_energy
+        units["kcal_to_j"] * ref_energy
     )
     T = round(T, precision)
     return T


### PR DESCRIPTION
In a previous PR I changed some of the temperature conversion functions to use `kcal/mol` and `ang_to_m` as they should be, but I forgot to add these to `base_units.py`. This PR fixes that issue as well as creating some unit tests for the functions in `unit_conversion.py` as well as a double-check of the conversion factors used in `base_units.py`