### PR TITLE
Large, single chain simulations

### DIFF
--- a/environment-nohoomd.yml
+++ b/environment-nohoomd.yml
@@ -23,5 +23,5 @@ dependencies:
   - signac=1.6.0
   - signac-flow=0.12.0
   - pip:
-      - git+https://github.com/chrisjonesBSU/mbuild.git@feat/polymer
+      - git+https://github.com/chrisjonesBSU/mbuild.git@nlist_tree
       - git+https://github.com/cmelab/uli-init.git@0.0.6

--- a/environment.yml
+++ b/environment.yml
@@ -24,5 +24,5 @@ dependencies:
   - signac=1.6.0
   - signac-flow=0.12.0
   - pip:
-      - git+https://github.com/chrisjonesBSU/mbuild.git@feat/polymer
+      - git+https://github.com/chrisjonesBSU/mbuild.git@nlist_tree
       - git+https://github.com/cmelab/uli-init.git@0.0.6

--- a/uli_init/simulate.py
+++ b/uli_init/simulate.py
@@ -637,7 +637,7 @@ class System:
         # Figure out correct box dimensions and expand the box to make the
         # PACKMOL step faster. Will shrink down to accurate L during simulation
         if len(mb_compounds) == 1:
-            self.density = 0.0001 / (self.polymer_lengths[0]**2)
+            self.density = 0.1 / (self.polymer_lengths[0]**2)
             L = self._calculate_L() * self.expand_factor
             system = mb_compounds[0]
             system.box = mb.box.Box(mins=[0, 0, 0], maxs=[L, L, L])

--- a/uli_init/simulate.py
+++ b/uli_init/simulate.py
@@ -37,6 +37,7 @@ class Simulation:
         dt=0.0001,
         auto_scale=True,
         ref_units=None,
+        nlist="cell",
         mode="gpu",
         gsd_write=1e4,
         log_write=1e3,
@@ -51,6 +52,7 @@ class Simulation:
         self.dt = dt
         self.auto_scale = auto_scale
         self.ref_units = ref_units
+        self.nlist = nlist
         self.mode = mode
         self.gsd_write = gsd_write
         self.log_write = log_write
@@ -110,12 +112,13 @@ class Simulation:
         sim = hoomd.context.initialize(hoomd_args)
         with sim:
             objs, refs = create_hoomd_simulation(
-                self.system_pmd,
-                self.ref_distance,
-                self.ref_mass,
-                self.ref_energy,
-                self.r_cut,
-                self.auto_scale,
+                structure=self.system_pmd,
+                ref_distance=self.ref_distance,
+                ref_mass=self.ref_mass,
+                ref_energy=self.ref_energy,
+                r_cut=self.r_cut,
+                n_list=self.nlist,
+                auto_scale=self.auto_scale,
             )
             hoomd_system = objs[1]
             init_snap = objs[0]
@@ -255,12 +258,13 @@ class Simulation:
         sim = hoomd.context.initialize(hoomd_args)
         with sim:
             objs, refs = create_hoomd_simulation(
-                self.system_pmd,
-                self.ref_distance,
-                self.ref_mass,
-                self.ref_energy,
-                self.r_cut,
-                self.auto_scale,
+                structure=self.system_pmd,
+                ref_distance=self.ref_distance,
+                ref_mass=self.ref_mass,
+                ref_energy=self.ref_energy,
+                r_cut=self.r_cut,
+                n_list=self.nlist,
+                auto_scale=self.auto_scale,
             )
             hoomd_system = objs[1]
             init_snap = objs[0]

--- a/uli_init/simulate.py
+++ b/uli_init/simulate.py
@@ -77,8 +77,9 @@ class Simulation:
 
         if system.type == "melt":
             # nm
-            self.reduced_target_L = self.system.target_L / self.ref_distance
+            self.reduced_target_L = (self.system.target_L*10) / self.ref_distance
             # angstroms
+#            self.reduced_init_L = (self.system_mb.Box[0]*10 / self.ref_distance)
             self.reduced_init_L = (self.system_pmd.box[0] / self.ref_distance)
 
             # TODO: Use target_box to generate non-cubic simulation volumes
@@ -636,9 +637,10 @@ class System:
         # Figure out correct box dimensions and expand the box to make the
         # PACKMOL step faster. Will shrink down to accurate L during simulation
         if len(mb_compounds) == 1:
+            self.density = 0.0001 / (self.polymer_lengths[0]**2)
             L = self._calculate_L() * self.expand_factor
             system = mb_compounds[0]
-            system.Box = mb.box.Box(mins=[0, 0, 0], maxs=[L, L, L])
+            system.box = mb.box.Box(mins=[0, 0, 0], maxs=[L, L, L])
             system.translate_to([L/2, L/2, L/2])
         else:
             L = self._calculate_L() * self.expand_factor
@@ -650,7 +652,7 @@ class System:
                 edge=0.9,
                 fix_orientation=True,
             )
-            system.Box = mb.box.Box([L, L, L])
+            system.box = mb.box.Box([L, L, L])
         return system
 
     def _type_system(self):

--- a/uli_init/simulate.py
+++ b/uli_init/simulate.py
@@ -636,10 +636,10 @@ class System:
         # Figure out correct box dimensions and expand the box to make the
         # PACKMOL step faster. Will shrink down to accurate L during simulation
         if len(mb_compounds) == 1:
-            L = self._calculate_L()
+            L = self._calculate_L() * self.expand_factor
             system = mb_compounds[0]
-            system.Box = mb.box.Box(mins=[-L, -L, -L], maxs=[L, L, L])
-            system.translate_to([0,0,0])
+            system.Box = mb.box.Box(mins=[0, 0, 0], maxs=[L, L, L])
+            system.translate_to([L/2, L/2, L/2])
         else:
             L = self._calculate_L() * self.expand_factor
             system = mb.packing.fill_box(

--- a/uli_init/simulate.py
+++ b/uli_init/simulate.py
@@ -638,11 +638,8 @@ class System:
         if len(mb_compounds) == 1:
             L = self._calculate_L()
             system = mb_compounds[0]
-            system.Box = mb.box.Box(mins=system.boundingbox.mins,
-                    maxs=system.boundingbox.maxs)
-            expand_factor = np.array([L,L,L]) / system.boundingbox.lengths
-            system.Box.mins *= expand_factor
-            system.Box.maxs *= expand_factor
+            system.Box = mb.box.Box(mins=[-L, -L, -L], maxs=[L, L, L])
+            system.translate_to([0,0,0])
         else:
             L = self._calculate_L() * self.expand_factor
             system = mb.packing.fill_box(

--- a/uli_init/simulate.py
+++ b/uli_init/simulate.py
@@ -631,16 +631,25 @@ class System:
 
         # Figure out correct box dimensions and expand the box to make the
         # PACKMOL step faster. Will shrink down to accurate L during simulation
-        L = self._calculate_L() * self.expand_factor 
-        system = mb.packing.fill_box(
-            compound=mb_compounds,
-            n_compounds=[1 for i in mb_compounds],
-            box=[L, L, L],
-            overlap=0.2,
-            edge=0.9,
-            fix_orientation=True,
-        )
-        system.Box = mb.box.Box([L, L, L])
+        if len(mb_compounds) == 1:
+            L = self._calculate_L()
+            system = mb_compounds[0]
+            system.Box = mb.box.Box(mins=system.boundingbox.mins,
+                    maxs=system.boundingbox.maxs)
+            expand_factor = np.array([L,L,L]) / system.boundingbox.lengths
+            system.Box.mins *= expand_factor
+            system.Box.maxs *= expand_factor
+        else:
+            L = self._calculate_L() * self.expand_factor
+            system = mb.packing.fill_box(
+                compound=mb_compounds,
+                n_compounds=[1 for i in mb_compounds],
+                box=[L, L, L],
+                overlap=0.2,
+                edge=0.9,
+                fix_orientation=True,
+            )
+            system.Box = mb.box.Box([L, L, L])
         return system
 
     def _type_system(self):

--- a/uli_init/tests/base_test.py
+++ b/uli_init/tests/base_test.py
@@ -75,3 +75,15 @@ class BaseTest:
             expand_factor=5
         )
         return pekk_sys
+
+    @pytest.fixture
+    def single_peek_chain(self):
+        chain = simulate.build_molecule("PEEK", 20, 1.0)
+        return chain
+
+    @pytest.fixture
+    def single_pekk_chain(self):
+        chain = simulate.build_molecule("PEKK", 20, 1.0)
+        return chain
+                            
+

--- a/uli_init/tests/base_test.py
+++ b/uli_init/tests/base_test.py
@@ -30,6 +30,7 @@ class BaseTest:
             polymer_lengths=[3],
             forcefield="gaff",
             remove_hydrogens=False,
+            expand_factor=5
         )
         return peek_sys
 
@@ -43,6 +44,7 @@ class BaseTest:
             polymer_lengths=[3],
             forcefield="gaff",
             remove_hydrogens=False,
+            expand_factor=5
         )
         return pekk_sys
 
@@ -56,6 +58,7 @@ class BaseTest:
             polymer_lengths=[3],
             forcefield="gaff",
             remove_hydrogens=True,
+            expand_factor=5
         )
         return peek_sys
 
@@ -69,5 +72,6 @@ class BaseTest:
             polymer_lengths=[3],
             forcefield="gaff",
             remove_hydrogens=True,
+            expand_factor=5
         )
         return pekk_sys

--- a/uli_init/tests/test_simulations.py
+++ b/uli_init/tests/test_simulations.py
@@ -81,3 +81,12 @@ class TestSimulate(BaseTest):
         simulation.anneal(
             kT_init=4, kT_final=2, step_sequence=[1e3, 1e3, 1e3], walls=True
         )
+
+    def test_single_chainis(self):
+        peek_chain = simulate.System("PEEK", 1.0, 0.10, 1, 20, "gaff")
+        pekk_chain = simulate.System("PEKK", 1.0, 0.10, 1, 20, "gaff")
+        peek_sim = simulate.Simulation(peek_chain, nlist="tree")
+        pekk_sim = simulate.Simulation(pekk_chain, nlist="tree")
+        peek_sim.quench(kT=1.0, n_steps=1e3, walls=False)
+        pekk_sim.quench(kT=1.0, n_steps=1e3, walls=False)
+        

--- a/uli_init/tests/test_systems.py
+++ b/uli_init/tests/test_systems.py
@@ -6,8 +6,6 @@ from uli_init.tests.base_test import BaseTest
 
 
 class TestSystems(BaseTest):
-    def test_pdi(self):
-        pass
 
     def test_build_peek(self):
         for i in range(5):
@@ -28,12 +26,6 @@ class TestSystems(BaseTest):
         random.seed()
         mix_sequence = simulate.random_sequence(para_weight=0.70, length=100)
         assert 100 - mix_sequence.count("P") == mix_sequence.count("M")
-
-    def test_gaff(self):
-        pass
-
-    def test_opls(self):
-        pass
 
     # check that we can load forcefield files
     def test_load_forcefiled(self):
@@ -93,6 +85,7 @@ class TestSystems(BaseTest):
             forcefield=None,
             assert_dihedrals=False,
             remove_hydrogens=False,
+            expand_factor = 7
         )
 
     # test PDI sampling with four combinations of argument values
@@ -108,6 +101,7 @@ class TestSystems(BaseTest):
             forcefield=None,
             assert_dihedrals=False,
             remove_hydrogens=False,
+            expand_factor = 7
         )
 
     def test_pdi_mn(self):
@@ -122,6 +116,7 @@ class TestSystems(BaseTest):
             forcefield=None,
             assert_dihedrals=False,
             remove_hydrogens=False,
+            expand_factor = 7
         )
 
     def test_mw_mn(self):
@@ -136,6 +131,7 @@ class TestSystems(BaseTest):
             forcefield=None,
             assert_dihedrals=False,
             remove_hydrogens=False,
+            expand_factor = 7
         )
 
     def test_pdi_mn_mw(self):
@@ -151,6 +147,7 @@ class TestSystems(BaseTest):
             forcefield=None,
             assert_dihedrals=False,
             remove_hydrogens=False,
+            expand_factor = 7
         )
 
     # make sure we correctly throw error when not enough PDI args

--- a/uli_init/tests/test_systems.py
+++ b/uli_init/tests/test_systems.py
@@ -7,6 +7,17 @@ from uli_init.tests.base_test import BaseTest
 
 class TestSystems(BaseTest):
 
+    def test_single_chain(self):
+        chain = simulate.System(
+                molecule="PEEK",
+                para_weight=1.0,
+                density=0.10,
+                n_compounds=1,
+                polymer_lengths=10,
+                forcefield="gaff",
+                remove_hydrogens=True
+                )
+
     def test_build_peek(self):
         for i in range(5):
             compound = simulate.build_molecule("PEEK", i + 1, para_weight=0.50)


### PR DESCRIPTION
This PR addresses a couple of issues related to starting and simulating large, single chains (e.g. 500mers) where the goal is to have large simulation volumes (i.e. box edge length ~ length of completely stretched out monomer).

**1. Skips PACKMOL**
- PACKMOL can struggle with very long molecules. One solution is to just keep increasing the `box_expand_factor`, but, if the goal is to simulate a single molecule, then we can skip the packing step completely and go straight from mbuild compound to foyer. 
- This PR now checks the length of `mb_compounds` after going through the `build_molecule` steps. If it's only one, then `fill_box` is skipped.

**2. Allows user to pass type of neighbor list used.**
- cell type neighbor lists scale with system volume, and these systems have a very low density. Using a cell type nlist was causing memory errors.
- For these simulations, we can pass `tree` to use a tree-type neighbor list which should be better at handling small N systems in very large volumes.