### PR TITLE
Manually define monomer sequence

### DIFF
--- a/uli_init/simulate.py
+++ b/uli_init/simulate.py
@@ -704,11 +704,27 @@ def build_molecule(molecule, length, sequence, para_weight):
         The monomer sequence to be used when building a polymer.
         Example) "AB" or "AAB"
         If you want a sequence to be generated randomly, use sequence="random"
+
     para_weight : float, limited to values between 0 and 1
         The relative amount of para configurations compared to meta.
         Passed into random_sequence() to determine the monomer sequence of the
         polymer.
         A 70/30 para to meta system would require a para_weight = 0.70
+
+    Notes:
+    ------
+    Any values entered for length and sequence should be compatible.
+    This is designed to follow the sequence until it has reached it's
+    terminal length.
+
+        For example:
+
+        A `length=5` and `sequence="PM"` would result in
+        `monomer_sequence = "PMPMP".
+
+        The same is true if `length` is shorter than the sequence length
+        A `lenght=3` and `sequence="PPMMM" would result in
+        `monomer_sequence = "PPM"`
 
     Returns
     -------

--- a/uli_init/simulate.py
+++ b/uli_init/simulate.py
@@ -497,7 +497,7 @@ class System:
         self.expand_factor = expand_factor
         self.type = "melt"
         
-        if self.sequence and self.para_weight:
+        if self.monomer_sequence and self.para_weight:
             raise ValueError(
                     "The para weight parameter can only be used when "
                     "generating random copolymer sequences. "

--- a/uli_init/simulate.py
+++ b/uli_init/simulate.py
@@ -711,19 +711,17 @@ def build_molecule(molecule, length, sequence, para_weight):
         polymer.
         A 70/30 para to meta system would require a para_weight = 0.70
 
-    Notes:
-    ------
+    Notes
+    -----
     Any values entered for length and sequence should be compatible.
     This is designed to follow the sequence until it has reached it's
-    terminal length.
-
-        For example:
+    terminal length. For example::
 
         A `length=5` and `sequence="PM"` would result in
         `monomer_sequence = "PMPMP".
 
         The same is true if `length` is shorter than the sequence length
-        A `lenght=3` and `sequence="PPMMM" would result in
+        A `lenght=3` and `sequence="PPMMM"` would result in
         `monomer_sequence = "PPM"`
 
     Returns

--- a/uli_init/simulate.py
+++ b/uli_init/simulate.py
@@ -464,10 +464,11 @@ class System:
     def __init__(
         self,
         molecule,
-        para_weight,
         density,
         n_compounds=None,
         polymer_lengths=None,
+        para_weight=None,
+        monomer_sequence=None,
         forcefield=None,
         epsilon=1e-7,
         sample_pdi=False,
@@ -481,20 +482,28 @@ class System:
         expand_factor=5
     ):
         self.molecule = molecule
-        self.para_weight = para_weight
         self.density = density
-        self.target_L = None
-        self.remove_hydrogens = remove_hydrogens
-        self.epsilon = epsilon
+        self.para_weight = para_weight
+        self.monomer_sequence = monomer_sequence
         self.forcefield = forcefield
+        self.target_L = None
+        self.epsilon = epsilon
+        self.remove_hydrogens = remove_hydrogens
         self.assert_dihedrals = assert_dihedrals
         self.seed = seed
         self.system_mass = 0
         self.para = 0
         self.meta = 0
-        self.type = "melt"
         self.expand_factor = expand_factor
-
+        self.type = "melt"
+        
+        if self.sequence and self.para_weight:
+            raise ValueError(
+                    "The para weight parameter can only be used when "
+                    "generating random copolymer sequences. "
+                    "If you are defining the monomer sequence, then set "
+                    "para_weight = None."
+                    )
         if sample_pdi:
             if isinstance(n_compounds, int):
                 self.n_compounds = n_compounds
@@ -612,17 +621,21 @@ class System:
         }
 
     def _pack(self):
+        if self.monomer_sequence:
+            sequence = self.monomer_sequence
+        else:
+            sequence = "random"
         random.seed(self.seed)
         mb_compounds = []
         for _length, _n in zip(self.polymer_lengths, self.n_compounds):
             for i in range(_n):
                 polymer, sequence = build_molecule(
-                    self.molecule, _length, self.para_weight
+                    self.molecule, _length, sequence, self.para_weight
                 )
 
                 mb_compounds.append(polymer)
-                self.para += sequence.count("para")
-                self.meta += sequence.count("meta")
+                self.para += sequence.count("P")
+                self.meta += sequence.count("M")
             mass = _n * np.sum(
                 ele.element_from_symbol(p.name).mass
                 for p in polymer.particles()
@@ -672,7 +685,7 @@ class System:
         return L
 
 
-def build_molecule(molecule, length, para_weight):
+def build_molecule(molecule, length, sequence, para_weight):
     """
     `build_molecule` uses SMILES strings to build up a polymer from monomers.
     The configuration of each monomer is determined by para_weight and the
@@ -687,6 +700,10 @@ def build_molecule(molecule, length, para_weight):
         Use the molecule name as seen in the .json file without including .json
     length : int
         The number of monomer units in the final polymer molecule
+    sequence : str, required
+        The monomer sequence to be used when building a polymer.
+        Example) "AB" or "AAB"
+        If you want a sequence to be generated randomly, use sequence="random"
     para_weight : float, limited to values between 0 and 1
         The relative amount of para configurations compared to meta.
         Passed into random_sequence() to determine the monomer sequence of the
@@ -704,7 +721,13 @@ def build_molecule(molecule, length, para_weight):
     mol_dict = json.load(f)
     f.close()
 
-    monomer_sequence = random_sequence(para_weight, length)
+    if sequence == "random":
+        monomer_sequence = random_sequence(para_weight, length)
+    else:
+        n = length // len(sequence)
+        monomer_sequence = sequence * n
+        monomer_sequence += sequence[:(length - len(monomer_sequence))]
+
     compound = Polymer()
     para = mb.load(mol_dict["para_smiles"], smiles=True, backend="rdkit")
     meta = mb.load(mol_dict["meta_smiles"], smiles=True, backend="rdkit")

--- a/uli_init/tests/base_test.py
+++ b/uli_init/tests/base_test.py
@@ -30,6 +30,7 @@ class BaseTest:
             polymer_lengths=[3],
             forcefield="gaff",
             remove_hydrogens=False,
+            expand_factor=5
         )
         return peek_sys
 
@@ -43,6 +44,7 @@ class BaseTest:
             polymer_lengths=[3],
             forcefield="gaff",
             remove_hydrogens=False,
+            expand_factor=5
         )
         return pekk_sys
 
@@ -56,6 +58,7 @@ class BaseTest:
             polymer_lengths=[3],
             forcefield="gaff",
             remove_hydrogens=True,
+            expand_factor=5
         )
         return peek_sys
 
@@ -69,5 +72,6 @@ class BaseTest:
             polymer_lengths=[3],
             forcefield="gaff",
             remove_hydrogens=True,
+            expand_factor=5
         )
         return pekk_sys

--- a/uli_init/tests/test_systems.py
+++ b/uli_init/tests/test_systems.py
@@ -6,8 +6,6 @@ from uli_init.tests.base_test import BaseTest
 
 
 class TestSystems(BaseTest):
-    def test_pdi(self):
-        pass
 
     def test_build_peek(self):
         for i in range(5):
@@ -28,12 +26,6 @@ class TestSystems(BaseTest):
         random.seed()
         mix_sequence = simulate.random_sequence(para_weight=0.70, length=100)
         assert 100 - mix_sequence.count("P") == mix_sequence.count("M")
-
-    def test_gaff(self):
-        pass
-
-    def test_opls(self):
-        pass
 
     # check that we can load forcefield files
     def test_load_forcefiled(self):
@@ -93,6 +85,7 @@ class TestSystems(BaseTest):
             forcefield=None,
             assert_dihedrals=False,
             remove_hydrogens=False,
+            expand_factor = 7
         )
 
     # test PDI sampling with four combinations of argument values
@@ -108,6 +101,7 @@ class TestSystems(BaseTest):
             forcefield=None,
             assert_dihedrals=False,
             remove_hydrogens=False,
+            expand_factor = 7
         )
 
     def test_pdi_mn(self):
@@ -122,6 +116,7 @@ class TestSystems(BaseTest):
             forcefield=None,
             assert_dihedrals=False,
             remove_hydrogens=False,
+            expand_factor = 7
         )
 
     def test_mw_mn(self):
@@ -136,6 +131,7 @@ class TestSystems(BaseTest):
             forcefield=None,
             assert_dihedrals=False,
             remove_hydrogens=False,
+            expand_factor = 7
         )
 
     def test_pdi_mn_mw(self):
@@ -151,6 +147,7 @@ class TestSystems(BaseTest):
             forcefield=None,
             assert_dihedrals=False,
             remove_hydrogens=False,
+            expand_factor = 7
         )
 
     # make sure we correctly throw error when not enough PDI args

--- a/uli_init/tests/test_systems.py
+++ b/uli_init/tests/test_systems.py
@@ -25,6 +25,18 @@ class TestSystems(BaseTest):
                     )
 
     def test_monomer_sequence(self):
+
+        with pytest.raises(ValueError):
+            system_even = simulate.System(
+                    molecule="PEEK",
+                    monomer_sequence="PM",
+                    para_weight=0.5,
+                    n_compounds = [1],
+                    polymer_lengths=[4],
+                    density=.1,
+                    remove_hydrogens=True
+                    )
+
         system_even = simulate.System(
                 molecule="PEEK",
                 monomer_sequence="PM",

--- a/uli_init/tests/test_systems.py
+++ b/uli_init/tests/test_systems.py
@@ -9,11 +9,52 @@ class TestSystems(BaseTest):
 
     def test_build_peek(self):
         for i in range(5):
-            compound = simulate.build_molecule("PEEK", i + 1, para_weight=0.50)
+            compound = simulate.build_molecule(
+                    "PEEK", i + 1,
+                    sequence = "random",
+                    para_weight=0.50
+                    )
 
     def test_build_pekk(self):
         for i in range(5):
-            compound = simulate.build_molecule("PEKK", i + 1, para_weight=0.50)
+            compound = simulate.build_molecule(
+                    "PEKK", 
+                    i + 1,
+                    sequence="random",
+                    para_weight=0.50
+                    )
+
+    def test_monomer_sequence(self):
+        system_even = simulate.System(
+                molecule="PEEK",
+                monomer_sequence="PM",
+                n_compounds = [1],
+                polymer_lengths=[4],
+                density=.1,
+                remove_hydrogens=True
+                )
+        assert system_even.para == system_even.meta  == 2
+
+        system_odd = simulate.System(
+                molecule="PEEK",
+                monomer_sequence="PM",
+                n_compounds = [1],
+                polymer_lengths=[5],
+                density=.1,
+                remove_hydrogens=True
+                )
+        assert system_odd.para == 3
+        assert system_odd.meta == 2
+
+        system_large_seq = simulate.System(
+                molecule="PEEK",
+                monomer_sequence="PMPMPMPMPM",
+                n_compounds = [1],
+                polymer_lengths=[4],
+                density=.1,
+                remove_hydrogens=True
+                )
+        assert system_large_seq.para == system_large_seq.meta == 2
 
     def test_para_weight(self):
         all_para = simulate.random_sequence(para_weight=1, length=10)
@@ -45,7 +86,7 @@ class TestSystems(BaseTest):
         simple_system = simulate.System(
             molecule="PEEK",
             para_weight=0.60,
-            density=1,
+            density=.1,
             n_compounds=[1],
             polymer_lengths=[2],
             forcefield="gaff",
@@ -66,7 +107,7 @@ class TestSystems(BaseTest):
         simple_system = simulate.System(
             molecule="PEEK",
             para_weight=0.60,
-            density=1,
+            density=.1,
             n_compounds=[1],
             polymer_lengths=[2],
             forcefield="gaff",
@@ -79,7 +120,7 @@ class TestSystems(BaseTest):
         simple_system = simulate.System(
             molecule="PEEK",
             para_weight=0.60,
-            density=1,
+            density=.1,
             n_compounds=[5, 4, 3, 2, 1],
             polymer_lengths=[2, 4, 5, 11, 22],
             forcefield=None,
@@ -93,7 +134,7 @@ class TestSystems(BaseTest):
         simple_system = simulate.System(
             molecule="PEEK",
             para_weight=0.60,
-            density=0.7,
+            density=0.1,
             n_compounds=3,
             sample_pdi=True,
             pdi=1.2,
@@ -108,7 +149,7 @@ class TestSystems(BaseTest):
         simple_system = simulate.System(
             molecule="PEEK",
             para_weight=0.60,
-            density=0.7,
+            density=0.1,
             n_compounds=3,
             sample_pdi=True,
             pdi=1.2,
@@ -123,7 +164,7 @@ class TestSystems(BaseTest):
         simple_system = simulate.System(
             molecule="PEEK",
             para_weight=0.60,
-            density=0.7,
+            density=0.1,
             n_compounds=3,
             sample_pdi=True,
             Mn=5.0,
@@ -138,7 +179,7 @@ class TestSystems(BaseTest):
         simple_system = simulate.System(
             molecule="PEEK",
             para_weight=0.60,
-            density=0.7,
+            density=0.1,
             n_compounds=3,
             sample_pdi=True,
             pdi=1.2,
@@ -156,7 +197,7 @@ class TestSystems(BaseTest):
             simple_system = simulate.System(
                 molecule="PEEK",
                 para_weight=0.60,
-                density=0.7,
+                density=0.1,
                 n_compounds=3,
                 sample_pdi=True,
                 pdi=1.2,
@@ -171,7 +212,7 @@ class TestSystems(BaseTest):
             simple_system = simulate.System(
                 molecule="PEEK",
                 para_weight=0.60,
-                density=0.7,
+                density=0.1,
                 n_compounds=3,
                 sample_pdi=True,
                 pdi=1.2,
@@ -188,7 +229,7 @@ class TestSystems(BaseTest):
         simple_system = simulate.System(
             molecule="PEEK",
             para_weight=0.60,
-            density=0.7,
+            density=0.1,
             n_compounds=3,
             sample_pdi=True,
             pdi=1.001,


### PR DESCRIPTION
So far, we've been able to control the number and lengths of the polymers generated, and the relative amount of para and meta configurations along the backbone, but the sequence has always been random.  This PR will allow a user to manually pass in a sequence.

It should work with any polymer length, and therefore still work with sampling from a PDI.  It's designed to follow the sequence until its reached it's terminal length.

For example, a `length = 5` and a `sequence = "PM"` should result in `monomer_sequence = "PMPMP"`.  Also, If the length is shorter than the sequence, the same is true. A `length = 3` and `sequence="PPMMM"` would result in `monomer_sequence="PPM"`