### PR TITLE
Fix gsd dumps, update environment to use mbuild 0.11.0

### DIFF
--- a/environment-nohoomd.yml
+++ b/environment-nohoomd.yml
@@ -2,18 +2,10 @@ name: uli-init
 channels:
   - conda-forge
 dependencies:
-  - ele=0.1.0
   - foyer=0.7.7
-  - garnett=0.7.1
   - gsd=2.4.0
-  - matplotlib
-  - mdtraj=1.9.5
-  - networkx=2.5
+  - mbuild=0.11.0
   - numpy=1.20.1
-  - openbabel=3.1.1
-  - oset=0.1.3
-  - packmol=20.010
-  - parmed=3.4.0
   - pip=21.0
   - pytest
   - pytest-cov
@@ -23,5 +15,4 @@ dependencies:
   - signac=1.6.0
   - signac-flow=0.12.0
   - pip:
-      - git+https://github.com/chrisjonesBSU/mbuild.git@feat/polymer
       - git+https://github.com/cmelab/uli-init.git@0.1.1

--- a/environment.yml
+++ b/environment.yml
@@ -2,19 +2,11 @@ name: uli-init
 channels:
   - conda-forge
 dependencies:
-  - ele=0.1.0
   - foyer=0.7.7
-  - garnett=0.7.1
   - gsd=2.4.0
   - hoomd=2.9.4
-  - matplotlib
-  - mdtraj=1.9.5
-  - networkx=2.5
+  - mbuild=0.11.0
   - numpy=1.20.1
-  - openbabel=3.1.1
-  - oset=0.1.3
-  - packmol=20.010
-  - parmed=3.4.0
   - pip=21.0
   - pytest
   - pytest-cov
@@ -24,5 +16,4 @@ dependencies:
   - signac=1.6.0
   - signac-flow=0.12.0
   - pip:
-      - git+https://github.com/chrisjonesBSU/mbuild.git@feat/polymer
       - git+https://github.com/cmelab/uli-init.git@0.1.1

--- a/uli_init/simulate.py
+++ b/uli_init/simulate.py
@@ -264,28 +264,6 @@ class Simulation:
                     )
             integrator.randomize_velocities(seed=self.seed)
 
-            if walls:
-                wall_origin = (init_snap.box.Lx / 2, 0, 0)
-                normal_vector = (-1, 0, 0)
-                wall_origin2 = (-init_snap.box.Lx / 2, 0, 0)
-                normal_vector2 = (1, 0, 0)
-                walls = wall.group(
-                    wall.plane(
-                        origin=wall_origin, normal=normal_vector, inside=True
-                        ),
-                    wall.plane(
-                        origin=wall_origin2, normal=normal_vector2, inside=True
-                        ),
-                )
-
-                wall_force = wall.lj(walls, r_cut=2.5)
-                wall_force.force_coeff.set(
-                    init_snap.particles.types,
-                    sigma=1.0,
-                    epsilon=1.0,
-                    r_extrap=0
-                )
-
             hoomd.dump.gsd(
                 "sim_traj.gsd",
                 period=self.gsd_write,
@@ -327,6 +305,26 @@ class Simulation:
                 integrator.randomize_velocities(seed=self.seed)
 
                 if walls:
+                    wall_origin = (init_snap.box.Lx / 2, 0, 0)
+                    normal_vector = (-1, 0, 0)
+                    wall_origin2 = (-init_snap.box.Lx / 2, 0, 0)
+                    normal_vector2 = (1, 0, 0)
+                    walls = wall.group(
+                        wall.plane(
+                            origin=wall_origin, normal=normal_vector, inside=True
+                            ),
+                        wall.plane(
+                            origin=wall_origin2, normal=normal_vector2, inside=True
+                            ),
+                    )
+
+                    wall_force = wall.lj(walls, r_cut=2.5)
+                    wall_force.force_coeff.set(
+                        init_snap.particles.types,
+                        sigma=1.0,
+                        epsilon=1.0,
+                        r_extrap=0
+                    )
                     step = 0
                     while step < shrink_steps:
                         hoomd.run_upto(step + shrink_period)

--- a/uli_init/simulate.py
+++ b/uli_init/simulate.py
@@ -146,15 +146,24 @@ class Simulation:
                     r_extrap=0
                 )
 
-            if shrink_kT and shrink_steps:
-                shrink_gsd = hoomd.dump.gsd(
-                    "traj-shrink.gsd",
-                    period=self.gsd_write,
-                    group=_all,
-                    phase=0,
-                    overwrite=True,
-                )
+            hoomd.dump.gsd(
+                "sim_traj.gsd",
+                period=self.gsd_write,
+                group=_all,
+                phase=0,
+                dynamic=["momentum"],
+                overwrite=False,
+            )
+            hoomd.analyze.log(
+                "sim_traj.log",
+                period=self.log_write,
+                quantities=self.log_quantities,
+                header_prefix="#",
+                overwrite=True,
+                phase=0,
+            )
 
+            if shrink_kT and shrink_steps:
                 x_variant = hoomd.variant.linear_interp([
                     (0, init_snap.box.Lx),
                     (shrink_steps, self.target_box[0] * 10)
@@ -198,30 +207,15 @@ class Simulation:
                         print(f"time elapsed: {time.time() - start}")
                 else:
                     hoomd.run_upto(shrink_steps)
-                shrink_gsd.disable()
                 box_updater.disable()
-            # Set up new gsd and log dumps for actual simulation
-            hoomd.dump.gsd(
-                "sim_traj.gsd",
-                period=self.gsd_write,
-                group=_all,
-                phase=0,
-                overwrite=True,
-            )
+
             gsd_restart = hoomd.dump.gsd(
                 "restart.gsd",
                 period=self.gsd_write,
                 group=_all,
                 truncate=True,
-                phase=0
-            )
-            hoomd.analyze.log(
-                "sim_traj.log",
-                period=self.log_write,
-                quantities=self.log_quantities,
-                header_prefix="#",
-                overwrite=True,
                 phase=0,
+                dynamic=["momentum"]
             )
             # Run the primary simulation
             integrator.set_params(kT=kT)
@@ -295,15 +289,24 @@ class Simulation:
                     r_extrap=0
                 )
 
-            if shrink_kT and shrink_steps:
-                shrink_gsd = hoomd.dump.gsd(
-                    "traj-shrink.gsd",
-                    period=self.gsd_write,
-                    group=_all,
-                    phase=0,
-                    overwrite=True,
-                )
+            hoomd.dump.gsd(
+                "sim_traj.gsd",
+                period=self.gsd_write,
+                group=_all,
+                phase=0,
+                dynamic=["momentum"],
+                overwrite=False,
+            )
+            hoomd.analyze.log(
+                "sim_traj.log",
+                period=self.log_write,
+                quantities=self.log_quantities,
+                header_prefix="#",
+                overwrite=True,
+                phase=0,
+            )
 
+            if shrink_kT and shrink_steps:
                 x_variant = hoomd.variant.linear_interp([
                     (0, self.reduced_init_L),
                     (shrink_steps, self.target_box[0] * 10)
@@ -341,30 +344,14 @@ class Simulation:
                         step += shrink_period
                 else:
                     hoomd.run_upto(shrink_steps)
-                shrink_gsd.disable()
                 box_updater.disable()
-            # Set up new log and gsd files for simulation:
-            hoomd.dump.gsd(
-                "sim_traj.gsd",
-                period=self.gsd_write,
-                group=_all,
-                phase=0,
-                overwrite=True,
-            )
             gsd_restart = hoomd.dump.gsd(
                 "restart.gsd",
                 period=self.gsd_write,
                 group=_all,
                 truncate=True,
-                phase=0
-            )
-            hoomd.analyze.log(
-                "sim_traj.log",
-                period=self.log_write,
-                quantities=self.log_quantities,
-                header_prefix="#",
-                overwrite=True,
                 phase=0,
+                dynamic=["momentum"]
             )
 
             for kT in schedule:  # Start iterating through annealing steps

--- a/uli_init/tests/test_simulations.py
+++ b/uli_init/tests/test_simulations.py
@@ -1,5 +1,5 @@
 from uli_init import simulate
-from uli_init.tests.base_test import BaseTest
+from base_test import BaseTest
 
 
 class TestSimulate(BaseTest):

--- a/uli_init/tests/test_systems.py
+++ b/uli_init/tests/test_systems.py
@@ -2,7 +2,7 @@ import pytest
 import random
 
 from uli_init import simulate
-from uli_init.tests.base_test import BaseTest
+from base_test import BaseTest
 
 
 class TestSystems(BaseTest):


### PR DESCRIPTION
The gsd files were not having the images written out and saved.  They should now do that.  

While I was at it, I also changed the environments to use mbuild 0.11.0 from conda rather than installing from my fork now that the polymer changes were merged in.  This also required some updates how slabs were initialized since the mbuild box API changed quite a bit.