### PR TITLE
fix environment files with mbuild upgrade

### DIFF
--- a/environment-nohoomd.yml
+++ b/environment-nohoomd.yml
@@ -1,22 +1,17 @@
 name: uli-init
 channels:
+  - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge
 dependencies:
-  - ele
-  - foyer=0.7.7
+  - foyer=0.9.2
   - gsd=2.4.0
-  - mdtraj
   - numpy=1.20.1
-  - packmol>=18
-  - parmed>=3.4.0
   - pip=21.0
   - pytest
   - pytest-cov
   - python=3.7
-  - rdkit=2021.03.1
   - scipy=1.6.0
   - signac=1.6.0
   - signac-flow=0.12.0
   - pip:
-      - git+https://github.com/chrisjonesBSU/mbuild.git@origin/fix/axis_transform 
       - git+https://github.com/cmelab/uli-init.git@0.2.0

--- a/environment-nohoomd.yml
+++ b/environment-nohoomd.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - foyer=0.9.2
   - gsd=2.4.0
+  - mbuild=0.12.0
   - numpy=1.20.1
   - pip=21.0
   - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -3,20 +3,15 @@ channels:
   - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge
 dependencies:
-  - ele
-  - foyer=0.7.7
+  - foyer=0.9.2
   - gsd=2.4.0
   - hoomd=2.9.4
   - mbuild=0.12.0
-  - mdtraj
   - numpy=1.20.1
-  - packmol>=18
-  - parmed>=3.4.0
   - pip=21.0
   - pytest
   - pytest-cov
   - python=3.7
-  - rdkit=2021.03.1
   - scipy=1.6.0
   - signac=1.6.0
   - signac-flow=0.12.0


### PR DESCRIPTION
Changes the foyer version, installs mbuild from conda, and uses by-pass for cudatoolkits when installing openmm via anaconda.